### PR TITLE
Implement ONLY_FULL_GROUP_BY compatibility (#15)

### DIFF
--- a/api/domains.php
+++ b/api/domains.php
@@ -35,7 +35,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         LEFT OUTER JOIN records R ON D.id = R.domain_id
         LEFT OUTER JOIN permissions P ON D.id = P.domain
         WHERE (P.user=? OR ?)
-        GROUP BY D.id
+        GROUP BY D.id, D.name, D.type
         HAVING
         (D.name LIKE ? OR ?) AND
         (D.type=? OR ?)


### PR DESCRIPTION
SQL92 requires that all columns (except aggregates) in the select clause
is part of the group by clause. SQL99 loosens this restriction a bit and
states that all columns in the select clause must be functionally
dependent of the group by clause.

This commit fixes all partial GROUP BY queries to be compatible with
SQL92. Previously, when MySQLs sql_mode included ONLY_FULL_GROUP_BY,
aggregating queries failed, resulting in an empty domain listing.