### PR TITLE
Conversion to PDO and adding Postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ This can be used e.g. for a dynamic DNS service, but also to obtain certificates
 from [Let's Encrypt](https://letsencrypt.org/) via the dns-01 challenge.
 
 PDNS Manager is written in PHP using [Bootstrap](http://getbootstrap.com/)
-and [jQuery](http://jquery.com/). The backend uses a MySQL or Maria DB
-database. The database is also used by Powerdns using the pdns-backend-mysql.
+and [jQuery](http://jquery.com/). The backend uses a MySQL/Maria DB or Postgres
+database. The database is also used by Powerdns using the pdns-backend-mysql or
+pdns-backend-pgsql backend.
 
 ## More information
 You can find more information and documentation as well as contact information on [pdnsmanager.lmitsystems.de](https://pdnsmanager.lmitsystems.de). There are also some tutorials to get you quickly up and running.

--- a/api/add-domain.php
+++ b/api/add-domain.php
@@ -35,32 +35,34 @@ if(!isset($_SESSION['type']) || $_SESSION['type'] != "admin") {
 
 if(isset($input->action) && $input->action == "addDomain") {
     $soaData = Array();
-    $soaData[] = $input->primary;
-    $soaData[] = mail_to_soa($input->mail);
+    $soaData[] = trim($input->primary);
+    $soaData[] = trim(mail_to_soa($input->mail));
     $soaData[] = date("Ymd") . "00";
     $soaData[] = $input->refresh;
     $soaData[] = $input->retry;
     $soaData[] = $input->expire;
     $soaData[] = $input->ttl;
     
+	$domainsName = trim($input->name);
+	
     $soaContent = implode(" ", $soaData);
     
     $db->beginTransaction();
     
     $stmt = $db->prepare("INSERT INTO domains(name,type) VALUES (:name,:type)");
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $domainsName, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();
     
     $stmt = $db->prepare("SELECT MAX(id) FROM domains WHERE name=:name AND type=:type");
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $domainsName, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();
 	$newDomainId = $stmt->fetchColumn();
     
     $stmt = $db->prepare("INSERT INTO records(domain_id,name,type,content,ttl) VALUES (:domain_id,:name,'SOA',:content,:ttl)");
 	$stmt->bindValue(':domain_id', $newDomainId, PDO::PARAM_INT);
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $domainsName, PDO::PARAM_STR);
 	$stmt->bindValue(':content', $soaContent, PDO::PARAM_STR);
 	$stmt->bindValue(':ttl', $input->ttl, PDO::PARAM_INT);
     $stmt->execute();

--- a/api/add-domain.php
+++ b/api/add-domain.php
@@ -52,7 +52,7 @@ if(isset($input->action) && $input->action == "addDomain") {
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();
     
-    $stmt = $db->prepare("SELECT id FROM domains WHERE name=:name AND type=:type LIMIT 1");
+    $stmt = $db->prepare("SELECT MAX(id) FROM domains WHERE name=:name AND type=:type");
 	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();

--- a/api/add-domain.php
+++ b/api/add-domain.php
@@ -35,15 +35,15 @@ if(!isset($_SESSION['type']) || $_SESSION['type'] != "admin") {
 
 if(isset($input->action) && $input->action == "addDomain") {
     $soaData = Array();
-    $soaData[] = trim($input->primary);
-    $soaData[] = trim(mail_to_soa($input->mail));
+    $soaData[] = strtolower(preg_replace('/\s+/', '', $input->primary));
+    $soaData[] = strtolower(mail_to_soa(preg_replace('/\s+/', '', $input->mail)));
     $soaData[] = date("Ymd") . "00";
     $soaData[] = $input->refresh;
     $soaData[] = $input->retry;
     $soaData[] = $input->expire;
     $soaData[] = $input->ttl;
     
-	$domainsName = trim($input->name);
+	$domainsName = strtolower(preg_replace('/\s+/', '', $input->name));
 	
     $soaContent = implode(" ", $soaData);
     

--- a/api/domains.php
+++ b/api/domains.php
@@ -39,7 +39,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         SELECT COUNT(*) AS anzahl
         FROM domains D
         LEFT OUTER JOIN permissions P ON D.id = P.domain
-        WHERE (P.\"user\"=:user1 OR :user2) AND 
+        WHERE (P.userid=:user1 OR :user2) AND 
         (D.name LIKE :name1 OR :name2) AND
         (D.type=:type1 OR :type2)
     ";
@@ -91,7 +91,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         FROM domains D
         LEFT OUTER JOIN records R ON D.id = R.domain_id
         LEFT OUTER JOIN permissions P ON D.id = P.domain
-        WHERE (P.\"user\"=:user1 OR :user2)
+        WHERE (P.userid=:user1 OR :user2)
         GROUP BY D.id, D.name, D.type
         HAVING
         (D.name LIKE :name1 OR :name2) AND

--- a/api/domains.php
+++ b/api/domains.php
@@ -40,7 +40,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         FROM domains D
         LEFT OUTER JOIN permissions P ON D.id = P.domain
         WHERE (P.user=:user1 OR :user2) AND 
-        (D.name LIKE :name1 OR name2) AND
+        (D.name LIKE :name1 OR :name2) AND
         (D.type=:type1 OR :type2)
     ";
 
@@ -74,6 +74,10 @@ if(isset($input->action) && $input->action == "getDomains") {
     $stmt->execute();
 	$result = $stmt->fetchColumn();
     
+	if ($result == 0) {
+		$result = 1;
+	}
+	
     // Initialize the return value
     $retval = Array();
     

--- a/api/domains.php
+++ b/api/domains.php
@@ -39,7 +39,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         SELECT COUNT(*) AS anzahl
         FROM domains D
         LEFT OUTER JOIN permissions P ON D.id = P.domain
-        WHERE (P.user=:user1 OR :user2) AND 
+        WHERE (P.\"user\"=:user1 OR :user2) AND 
         (D.name LIKE :name1 OR :name2) AND
         (D.type=:type1 OR :type2)
     ";
@@ -91,7 +91,7 @@ if(isset($input->action) && $input->action == "getDomains") {
         FROM domains D
         LEFT OUTER JOIN records R ON D.id = R.domain_id
         LEFT OUTER JOIN permissions P ON D.id = P.domain
-        WHERE (P.user=:user1 OR :user2)
+        WHERE (P.\"user\"=:user1 OR :user2)
         GROUP BY D.id, D.name, D.type
         HAVING
         (D.name LIKE :name1 OR :name2) AND
@@ -120,13 +120,13 @@ if(isset($input->action) && $input->action == "getDomains") {
     
     /*
      * Now the number of entries gets limited to the domainRows config value.
-     * SQL LIMIT is used for that:
-     * LIMIT lower, upper
-     * Note that LIMIT 0,4 returns the first five rows!
+     * SQL LIMIT and OFFSET is used for that:
+     * LIMIT upper OFFSET lower
+     * Note that LIMIT 5 OFFSET 0 returns the first five rows!
      */
     $lower_limit = ($config['domain_rows'] * ($input->page - 1));
     
-    $sql .= " LIMIT " . $lower_limit . ", " . $config['domain_rows'];
+    $sql .= " LIMIT " . $config['domain_rows'] . " OFFSET " . $lower_limit;
     
     $stmt = $db->prepare($sql);
 
@@ -156,7 +156,7 @@ if(isset($input->action) && $input->action == "getDomains") {
 	$stmt->bindValue(':type1', $type_filter, PDO::PARAM_INT);
 	$stmt->bindValue(':type2', $type_filter_used, PDO::PARAM_INT);
     $stmt->execute();
-
+	
     while($obj = $stmt->fetchObject()) {
         $retval['data'][] = $obj;
     }

--- a/api/edit-master.php
+++ b/api/edit-master.php
@@ -142,7 +142,7 @@ if(isset($input->action) && $input->action == "getSoa") {
     
     $retval = Array();
     
-    $retval['primary'] = preg_replace('/\\.$/', "", $content[0]);
+    $retval['primary'] = $content[0];
     $retval['email'] = soa_to_mail($content[1]);
     $retval['serial'] = $content[2];
     $retval['refresh'] = $content[3];
@@ -184,8 +184,8 @@ if(isset($input->action) && $input->action == "saveSoa") {
     $content = explode(" ", $content);    
     $serial = $content[2];
         
-    $newsoa = trim($input->primary) . " ";
-    $newsoa .= trim(mail_to_soa($input->email)) . " ";
+    $newsoa = strtolower(preg_replace('/\s+/', '', $input->primary)) . " ";
+    $newsoa .= strtolower(mail_to_soa(preg_replace('/\s+/', '', $input->email))) . " ";
     $newsoa .= $serial . " ";
     $newsoa .= $input->refresh . " ";
     $newsoa .= $input->retry . " ";
@@ -208,7 +208,7 @@ if(isset($input->action) && $input->action == "saveSoa") {
 //Action for saving Record
 if(isset($input->action) && $input->action == "saveRecord") {
     $domainId = $input->domain;
-    $recordName = trim($input->name);
+    $recordName = strtolower(preg_replace('/\s+/', '', $input->name));
 	$recordContent = trim($input->content);
 	
     $stmt = $db->prepare("UPDATE records SET name=:name,type=:type,content=:content,ttl=:ttl,prio=:prio WHERE id=:id AND domain_id=:domain_id");
@@ -226,7 +226,7 @@ if(isset($input->action) && $input->action == "saveRecord") {
 //Action for adding Record
 if(isset($input->action) && $input->action == "addRecord") {
     $domainId = $input->domain;
-	$recordName = trim($input->name);
+	$recordName = strtolower(preg_replace('/\s+/', '', $input->name));
 	$recordContent = trim($input->content);
 	
     $db->beginTransaction();

--- a/api/edit-master.php
+++ b/api/edit-master.php
@@ -31,7 +31,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 
 //Permission check
 if(isset($input->domain)) {
-	$permquery = $db->prepare("SELECT COUNT(*) FROM permissions WHERE user=:user AND domain=:domain");
+	$permquery = $db->prepare("SELECT COUNT(*) FROM permissions WHERE \"user\"=:user AND domain=:domain");
 	$permquery->bindValue(':user', $_SESSION['id'], PDO::PARAM_INT);
 	$permquery->bindValue(':domain', $input->domain, PDO::PARAM_INT);
     $permquery->execute();

--- a/api/edit-master.php
+++ b/api/edit-master.php
@@ -31,7 +31,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 
 //Permission check
 if(isset($input->domain)) {
-	$permquery = $db->prepare("SELECT COUNT(*) FROM permissions WHERE \"user\"=:user AND domain=:domain");
+	$permquery = $db->prepare("SELECT COUNT(*) FROM permissions WHERE userid=:user AND domain=:domain");
 	$permquery->bindValue(':user', $_SESSION['id'], PDO::PARAM_INT);
 	$permquery->bindValue(':domain', $input->domain, PDO::PARAM_INT);
     $permquery->execute();

--- a/api/edit-master.php
+++ b/api/edit-master.php
@@ -176,7 +176,7 @@ if(isset($input->action) && $input->action == "saveSoa") {
     
 	$db->beginTransaction();
     
-    $stmt = $db->prepare("SELECT content FROM records WHERE type='SOA' AND domain_id=:domain_id");
+    $stmt = $db->prepare("SELECT content FROM records WHERE type='SOA' AND domain_id=:domain_id LIMIT 1");
 	$stmt->bindValue(':domain_id', $domainId, PDO::PARAM_INT);
     $stmt->execute();
 	$content = $stmt->fetchColumn();;

--- a/api/edit-master.php
+++ b/api/edit-master.php
@@ -184,8 +184,8 @@ if(isset($input->action) && $input->action == "saveSoa") {
     $content = explode(" ", $content);    
     $serial = $content[2];
         
-    $newsoa = $input->primary . " ";
-    $newsoa .= mail_to_soa($input->email) . " ";
+    $newsoa = trim($input->primary) . " ";
+    $newsoa .= trim(mail_to_soa($input->email)) . " ";
     $newsoa .= $serial . " ";
     $newsoa .= $input->refresh . " ";
     $newsoa .= $input->retry . " ";
@@ -208,11 +208,13 @@ if(isset($input->action) && $input->action == "saveSoa") {
 //Action for saving Record
 if(isset($input->action) && $input->action == "saveRecord") {
     $domainId = $input->domain;
-    
+    $recordName = trim($input->name);
+	$recordContent = trim($input->content);
+	
     $stmt = $db->prepare("UPDATE records SET name=:name,type=:type,content=:content,ttl=:ttl,prio=:prio WHERE id=:id AND domain_id=:domain_id");
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $recordName, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
-	$stmt->bindValue(':content', $input->content, PDO::PARAM_STR);
+	$stmt->bindValue(':content', $recordContent, PDO::PARAM_STR);
 	$stmt->bindValue(':ttl', $input->ttl, PDO::PARAM_INT);
 	$stmt->bindValue(':prio', $input->prio, PDO::PARAM_INT);
 	$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
@@ -224,22 +226,25 @@ if(isset($input->action) && $input->action == "saveRecord") {
 //Action for adding Record
 if(isset($input->action) && $input->action == "addRecord") {
     $domainId = $input->domain;
+	$recordName = trim($input->name);
+	$recordContent = trim($input->content);
+	
     $db->beginTransaction();
 	
     $stmt = $db->prepare("INSERT INTO records (domain_id, name, type, content, prio, ttl) VALUES (:domain_id,:name,:type,:content,:prio,:ttl)");
 	$stmt->bindValue(':domain_id', $domainId, PDO::PARAM_INT);
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $recordName, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
-	$stmt->bindValue(':content', $input->content, PDO::PARAM_STR);
+	$stmt->bindValue(':content', $recordContent, PDO::PARAM_STR);
 	$stmt->bindValue(':ttl', $input->ttl, PDO::PARAM_INT);
 	$stmt->bindValue(':prio', $input->prio, PDO::PARAM_INT);
     $stmt->execute();
 	
     $stmt = $db->prepare("SELECT MAX(id) FROM records WHERE domain_id=:domain_id AND name=:name AND type=:type AND content=:content AND prio=:prio AND ttl=:ttl");
 	$stmt->bindValue(':domain_id', $domainId, PDO::PARAM_INT);
-	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
+	$stmt->bindValue(':name', $recordName, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
-	$stmt->bindValue(':content', $input->content, PDO::PARAM_STR);
+	$stmt->bindValue(':content', $recordContent, PDO::PARAM_STR);
 	$stmt->bindValue(':ttl', $input->ttl, PDO::PARAM_INT);
 	$stmt->bindValue(':prio', $input->prio, PDO::PARAM_INT);
     $stmt->execute();

--- a/api/edit-remote.php
+++ b/api/edit-remote.php
@@ -29,7 +29,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 
 //Permission check
 if(isset($input->record)) {
-    $permquery = $db->prepare("SELECT COUNT(*) FROM records JOIN permissions ON records.domain_id=permissions.domain WHERE user=:user AND records.id=:id");
+    $permquery = $db->prepare("SELECT COUNT(*) FROM records JOIN permissions ON records.domain_id=permissions.domain WHERE \"user\"=:user AND records.id=:id");
 	$permquery->bindValue(':user', $_SESSION['id'], PDO::PARAM_INT);
 	$permquery->bindValue(':id', $input->record, PDO::PARAM_INT);
     $permquery->execute();

--- a/api/edit-remote.php
+++ b/api/edit-remote.php
@@ -29,7 +29,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 
 //Permission check
 if(isset($input->record)) {
-    $permquery = $db->prepare("SELECT COUNT(*) FROM records JOIN permissions ON records.domain_id=permissions.domain WHERE \"user\"=:user AND records.id=:id");
+    $permquery = $db->prepare("SELECT COUNT(*) FROM records JOIN permissions ON records.domain_id=permissions.domain WHERE userid=:user AND records.id=:id");
 	$permquery->bindValue(':user', $_SESSION['id'], PDO::PARAM_INT);
 	$permquery->bindValue(':id', $input->record, PDO::PARAM_INT);
     $permquery->execute();

--- a/api/edit-user.php
+++ b/api/edit-user.php
@@ -37,14 +37,14 @@ if(isset($input->action) && $input->action == "addUser") {
     
     $db->beginTransaction();
     
-    $stmt = $db->prepare("INSERT INTO \"user\"(name,password,type) VALUES (:name,:password,:type)");
+    $stmt = $db->prepare("INSERT INTO users(name,password,type) VALUES (:name,:password,:type)");
 	
 	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();
     
-	$stmt = $db->prepare("SELECT MAX(id) FROM \"user\" WHERE name=:name AND password=:password AND type=:type");
+	$stmt = $db->prepare("SELECT MAX(id) FROM users WHERE name=:name AND password=:password AND type=:type");
 	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
@@ -58,7 +58,7 @@ if(isset($input->action) && $input->action == "addUser") {
 }
 
 if(isset($input->action) && $input->action == "getUserData") {
-    $stmt = $db->prepare("SELECT name,type FROM \"user\" WHERE id=:id LIMIT 1");
+    $stmt = $db->prepare("SELECT name,type FROM users WHERE id=:id LIMIT 1");
 	$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
     $stmt->execute();
 	$stmt->bindColumn('name', $userName);
@@ -73,14 +73,14 @@ if(isset($input->action) && $input->action == "getUserData") {
 if(isset($input->action) && $input->action == "saveUserChanges") {
     if(isset($input->password)) {
         $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
-        $stmt = $db->prepare("UPDATE \"user\" SET name=:name,password=:password,type=:type WHERE id=:id");
+        $stmt = $db->prepare("UPDATE users SET name=:name,password=:password,type=:type WHERE id=:id");
 		$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 		$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 		$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
 		$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
         $stmt->execute();
     } else {
-        $stmt = $db->prepare("UPDATE \"user\" SET name=:name,type=:type WHERE id=:id");
+        $stmt = $db->prepare("UPDATE users SET name=:name,type=:type WHERE id=:id");
 		$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 		$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
 		$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
@@ -94,7 +94,7 @@ if(isset($input->action) && $input->action == "getPermissions") {
         SELECT D.id,D.name 
         FROM permissions P
         JOIN domains D ON P.domain=D.id
-        WHERE P.\"user\"=:user
+        WHERE P.userid=:user
     ");
     
     $stmt->bindValue(':user', $input->id, PDO::PARAM_INT);
@@ -109,7 +109,7 @@ if(isset($input->action) && $input->action == "getPermissions") {
 
 if(isset($input->action) && $input->action == "removePermission") {
 
-    $stmt = $db->prepare("DELETE FROM permissions WHERE \"user\"=:user AND domain=:domain");
+    $stmt = $db->prepare("DELETE FROM permissions WHERE userid=:user AND domain=:domain");
     
 	$stmt->bindValue(':user', $input->userId, PDO::PARAM_INT);
 	$stmt->bindValue(':domain', $input->domainId, PDO::PARAM_INT);
@@ -117,7 +117,7 @@ if(isset($input->action) && $input->action == "removePermission") {
 }
 
 if(isset($input->action) && $input->action == "searchDomains" && isset($input->term)) {
-    $stmt = $db->prepare("SELECT id,name AS text FROM domains WHERE name LIKE :name  AND id NOT IN(SELECT domain FROM permissions WHERE \"user\"=:user)");
+    $stmt = $db->prepare("SELECT id,name AS text FROM domains WHERE name LIKE :name  AND id NOT IN(SELECT domain FROM permissions WHERE userid=:user)");
 
     $searchTerm = "%" . $input->term . "%";
     
@@ -133,7 +133,7 @@ if(isset($input->action) && $input->action == "searchDomains" && isset($input->t
 }
 
 if(isset($input->action) && $input->action == "addPermissions") {
-    $stmt = $db->prepare("INSERT INTO permissions(\"user\",domain) VALUES (:user,:domain)");
+    $stmt = $db->prepare("INSERT INTO permissions(userid,domain) VALUES (:user,:domain)");
 
     foreach($input->domains as $domain) {
 		$stmt->bindValue(':user', $input->userId, PDO::PARAM_INT);

--- a/api/edit-user.php
+++ b/api/edit-user.php
@@ -37,14 +37,14 @@ if(isset($input->action) && $input->action == "addUser") {
     
     $db->beginTransaction();
     
-    $stmt = $db->prepare("INSERT INTO user(name,password,type) VALUES (:name,:password,:type)");
+    $stmt = $db->prepare("INSERT INTO \"user\"(name,password,type) VALUES (:name,:password,:type)");
 	
 	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
     $stmt->execute();
     
-	$stmt = $db->prepare("SELECT MAX(id) FROM user WHERE name=:name AND password=:password AND type=:type");
+	$stmt = $db->prepare("SELECT MAX(id) FROM \"user\" WHERE name=:name AND password=:password AND type=:type");
 	$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
@@ -58,7 +58,7 @@ if(isset($input->action) && $input->action == "addUser") {
 }
 
 if(isset($input->action) && $input->action == "getUserData") {
-    $stmt = $db->prepare("SELECT name,type FROM user WHERE id=:id LIMIT 1");
+    $stmt = $db->prepare("SELECT name,type FROM \"user\" WHERE id=:id LIMIT 1");
 	$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
     $stmt->execute();
 	$stmt->bindColumn('name', $userName);
@@ -73,14 +73,14 @@ if(isset($input->action) && $input->action == "getUserData") {
 if(isset($input->action) && $input->action == "saveUserChanges") {
     if(isset($input->password)) {
         $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
-        $stmt = $db->prepare("UPDATE user SET name=:name,password=:password,type=:type WHERE id=:id");
+        $stmt = $db->prepare("UPDATE \"user\" SET name=:name,password=:password,type=:type WHERE id=:id");
 		$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 		$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 		$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
 		$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
         $stmt->execute();
     } else {
-        $stmt = $db->prepare("UPDATE user SET name=:name,type=:type WHERE id=:id");
+        $stmt = $db->prepare("UPDATE \"user\" SET name=:name,type=:type WHERE id=:id");
 		$stmt->bindValue(':name', $input->name, PDO::PARAM_STR);
 		$stmt->bindValue(':type', $input->type, PDO::PARAM_STR);
 		$stmt->bindValue(':id', $input->id, PDO::PARAM_INT);
@@ -94,7 +94,7 @@ if(isset($input->action) && $input->action == "getPermissions") {
         SELECT D.id,D.name 
         FROM permissions P
         JOIN domains D ON P.domain=D.id
-        WHERE P.user=:user
+        WHERE P.\"user\"=:user
     ");
     
     $stmt->bindValue(':user', $input->id, PDO::PARAM_INT);
@@ -109,7 +109,7 @@ if(isset($input->action) && $input->action == "getPermissions") {
 
 if(isset($input->action) && $input->action == "removePermission") {
 
-    $stmt = $db->prepare("DELETE FROM permissions WHERE user=:user AND domain=:domain");
+    $stmt = $db->prepare("DELETE FROM permissions WHERE \"user\"=:user AND domain=:domain");
     
 	$stmt->bindValue(':user', $input->userId, PDO::PARAM_INT);
 	$stmt->bindValue(':domain', $input->domainId, PDO::PARAM_INT);
@@ -117,7 +117,7 @@ if(isset($input->action) && $input->action == "removePermission") {
 }
 
 if(isset($input->action) && $input->action == "searchDomains" && isset($input->term)) {
-    $stmt = $db->prepare("SELECT id,name AS text FROM domains WHERE name LIKE :name  AND id NOT IN(SELECT domain FROM permissions WHERE user=:user)");
+    $stmt = $db->prepare("SELECT id,name AS text FROM domains WHERE name LIKE :name  AND id NOT IN(SELECT domain FROM permissions WHERE \"user\"=:user)");
 
     $searchTerm = "%" . $input->term . "%";
     
@@ -133,7 +133,7 @@ if(isset($input->action) && $input->action == "searchDomains" && isset($input->t
 }
 
 if(isset($input->action) && $input->action == "addPermissions") {
-    $stmt = $db->prepare("INSERT INTO permissions(user,domain) VALUES (:user,:domain)");
+    $stmt = $db->prepare("INSERT INTO permissions(\"user\",domain) VALUES (:user,:domain)");
 
     foreach($input->domains as $domain) {
 		$stmt->bindValue(':user', $input->userId, PDO::PARAM_INT);

--- a/api/index.php
+++ b/api/index.php
@@ -21,7 +21,7 @@ require_once '../lib/database.php';
 
 $input = json_decode(file_get_contents('php://input'));
 
-$stmt = $db->prepare("SELECT id,password,type FROM \"user\" WHERE name=:name LIMIT 1");
+$stmt = $db->prepare("SELECT id,password,type FROM users WHERE name=:name LIMIT 1");
 $stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
 $stmt->execute();
 $stmt->bindColumn('id', $id);

--- a/api/index.php
+++ b/api/index.php
@@ -21,7 +21,7 @@ require_once '../lib/database.php';
 
 $input = json_decode(file_get_contents('php://input'));
 
-$stmt = $db->prepare("SELECT id,password,type FROM user WHERE name=:name LIMIT 1");
+$stmt = $db->prepare("SELECT id,password,type FROM \"user\" WHERE name=:name LIMIT 1");
 $stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
 $stmt->execute();
 $stmt->bindColumn('id', $id);

--- a/api/index.php
+++ b/api/index.php
@@ -21,12 +21,13 @@ require_once '../lib/database.php';
 
 $input = json_decode(file_get_contents('php://input'));
 
-$sql = $db->prepare("SELECT id,password,type FROM user WHERE name=?");
-$sql->bind_param("s", $input->user);
+$sql = $db->prepare("SELECT id,password,type FROM user WHERE name=:name LIMIT 1");
+$stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
 $sql->execute();
-
-$sql->bind_result($id, $password, $type);
-$sql->fetch();
+$stmt->bindColumn('id', $id);
+$stmt->bindColumn('password', $password);
+$stmt->bindColumn('type', $type);
+$stmt->fetch(PDO::FETCH_BOUND);
 
 if (password_verify($input->password, $password)) {
     $retval['status'] = "success";

--- a/api/index.php
+++ b/api/index.php
@@ -21,9 +21,9 @@ require_once '../lib/database.php';
 
 $input = json_decode(file_get_contents('php://input'));
 
-$sql = $db->prepare("SELECT id,password,type FROM user WHERE name=:name LIMIT 1");
+$stmt = $db->prepare("SELECT id,password,type FROM user WHERE name=:name LIMIT 1");
 $stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
-$sql->execute();
+$stmt->execute();
 $stmt->bindColumn('id', $id);
 $stmt->bindColumn('password', $password);
 $stmt->bindColumn('type', $type);

--- a/api/install.php
+++ b/api/install.php
@@ -207,6 +207,7 @@ CREATE TABLE IF NOT EXISTS permissions (
 );
 
 CREATE INDEX IF NOT EXISTS perm_domain_index ON permissions(domain);
+CREATE INDEX IF NOT EXISTS perm_userid_index ON permissions(userid);
 
 CREATE TABLE IF NOT EXISTS remote (
   id 				SERIAL PRIMARY KEY,

--- a/api/install.php
+++ b/api/install.php
@@ -295,7 +295,7 @@ try {
 }
 catch (PDOException $e) {
     $retval['status'] = "error";
-    $retval['message'] = $e;
+    $retval['message'] = serialize($e);
 }
 if (!isset($retval)) {
     $passwordHash = password_hash($input->userPassword, PASSWORD_DEFAULT);
@@ -316,11 +316,17 @@ if (!isset($retval)) {
     $configFile[] = '$config[\'db_password\'] = \'' . addslashes($input->password) . "';";
     $configFile[] = '$config[\'db_name\'] = \'' . addslashes($input->database) . "';";
     $configFile[] = '$config[\'db_port\'] = ' . addslashes($input->port) . ";";
-    $configFile[] = '$config[\'db_type\'] = ' . addslashes($input->type) . ";";
-		
-    file_put_contents("../config/config-user.php", implode("\n", $configFile));
-    
-    $retval['status'] = "success";
+    $configFile[] = '$config[\'db_type\'] = \'' . addslashes($input->type) . "';";
+	
+	try {
+		file_put_contents("../config/config-user.php", implode("\n", $configFile));
+		$retval['status'] = "success";
+	}
+	catch (Exception $e) {
+		$retval['status'] = "error";
+		$retval['message'] = serialize($e);
+	}
+	
 }
 
 if(isset($retval)) {

--- a/api/password.php
+++ b/api/password.php
@@ -30,7 +30,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 if(isset($input->action) && $input->action == "changePassword") {
     $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
     
-    $stmt = $db->prepare("UPDATE \"user\" SET password=:password WHERE id=:id");
+    $stmt = $db->prepare("UPDATE users SET password=:password WHERE id=:id");
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':id', $_SESSION['id'], PDO::PARAM_INT);
     $stmt->execute();

--- a/api/password.php
+++ b/api/password.php
@@ -30,7 +30,7 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 if(isset($input->action) && $input->action == "changePassword") {
     $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
     
-    $stmt = $db->prepare("UPDATE user SET password=:password WHERE id=:id");
+    $stmt = $db->prepare("UPDATE \"user\" SET password=:password WHERE id=:id");
 	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
 	$stmt->bindValue(':id', $_SESSION['id'], PDO::PARAM_INT);
     $stmt->execute();

--- a/api/password.php
+++ b/api/password.php
@@ -30,10 +30,10 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
 if(isset($input->action) && $input->action == "changePassword") {
     $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
     
-    $stmt = $db->prepare("UPDATE user SET password=? WHERE id=?");
-    $stmt->bind_param("si", $passwordHash, $_SESSION['id']);
+    $stmt = $db->prepare("UPDATE user SET password=:password WHERE id=:id");
+	$stmt->bindValue(':password', $passwordHash, PDO::PARAM_STR);
+	$stmt->bindValue(':id', $_SESSION['id'], PDO::PARAM_INT);
     $stmt->execute();
-    $stmt->close();
 }
 
 if(isset($retval)) {

--- a/api/upgrade.php
+++ b/api/upgrade.php
@@ -29,7 +29,7 @@ if(isset($input->action) && $input->action == "getVersions") {
 
 if(isset($input->action) && $input->action == "requestUpgrade") {
     $currentVersion = getVersion($db);
-    
+    $dbType = $config['db_type'];
     if($currentVersion < 1) {
         $sql["mysql"] = "
             CREATE TABLE IF NOT EXISTS remote (
@@ -54,8 +54,8 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
             
             INSERT INTO options(name,value) VALUES ('schema_version', 1);
         ";
-        $sql["pgsql"] = "";
-		$stmt = $db->query($sql[$config['db_type']]);
+        $sql["pgsql"] = "INSERT INTO options(name,value) VALUES ('schema_version', 1);";
+		$stmt = $db->query($sql[$dbType]);
 		while ($stmt->nextRowset()) {;}
     }
     if($currentVersion < 2) {
@@ -79,13 +79,13 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
               
             UPDATE options SET value=2 WHERE name='schema_version';
         ";
-        $sql["pgsql"] = "";
-		$stmt = $db->query($sql[$config['db_type']]);
+        $sql["pgsql"] = "UPDATE options SET value=2 WHERE name='schema_version';";
+		$stmt = $db->query($sql[$dbType]);
 		while ($stmt->nextRowset()) {;}
     }
     if($currentVersion < 3) {
         $sql["mysql"] = "
-            CREATE TABLE domainmetadata (
+            CREATE TABLE IF NOT EXISTS domainmetadata (
                 id INT AUTO_INCREMENT,
                 domain_id INT NOT NULL,
                 kind VARCHAR(32),
@@ -98,9 +98,10 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
             
             UPDATE options SET value=3 WHERE name='schema_version';
         ";
-        $sql["pgsql"] = "";
-		$stmt = $db->query($sql[$config['db_type']]);
+        $sql["pgsql"] = "UPDATE options SET value=3 WHERE name='schema_version';";
+		$stmt = $db->query($sql[$dbType]);
 		while ($stmt->nextRowset()) {;}
+		
     }
     if($currentVersion < 4) {
         $sql["mysql"] = "
@@ -147,8 +148,8 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
 			
 			UPDATE options SET value=4 WHERE name='schema_version';
         ";
-        $sql["pgsql"] = "";
-		$stmt = $db->query($sql[$config['db_type']]);
+        $sql["pgsql"] = "UPDATE options SET value=4 WHERE name='schema_version';";
+		$stmt = $db->query($sql[$dbType]);
 		while ($stmt->nextRowset()) {;}
     }
     $retval['status'] = "success";

--- a/api/upgrade.php
+++ b/api/upgrade.php
@@ -55,8 +55,17 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
             INSERT INTO options(name,value) VALUES ('schema_version', 1);
         ";
         $sql["pgsql"] = "INSERT INTO options(name,value) VALUES ('schema_version', 1);";
-		$stmt = $db->query($sql[$dbType]);
-		while ($stmt->nextRowset()) {;}
+		$queries = explode(";", $sql[$dbType]);
+		
+		$db->beginTransaction();
+		
+		foreach ($queries as $query) {
+			if (preg_replace('/\s+/', '', $query) != '') {
+				$db->exec($query);
+			}
+		}
+
+		$db->commit();
     }
     if($currentVersion < 2) {
         $sql["mysql"] = "
@@ -80,8 +89,18 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
             UPDATE options SET value=2 WHERE name='schema_version';
         ";
         $sql["pgsql"] = "UPDATE options SET value=2 WHERE name='schema_version';";
-		$stmt = $db->query($sql[$dbType]);
-		while ($stmt->nextRowset()) {;}
+		$queries = explode(";", $sql[$dbType]);
+		
+		$db->beginTransaction();
+		
+		foreach ($queries as $query) {
+			if (preg_replace('/\s+/', '', $query) != '') {
+				$db->exec($query);
+			}
+		}
+
+		$db->commit();
+	
     }
     if($currentVersion < 3) {
         $sql["mysql"] = "
@@ -99,8 +118,17 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
             UPDATE options SET value=3 WHERE name='schema_version';
         ";
         $sql["pgsql"] = "UPDATE options SET value=3 WHERE name='schema_version';";
-		$stmt = $db->query($sql[$dbType]);
-		while ($stmt->nextRowset()) {;}
+		$queries = explode(";", $sql[$dbType]);
+		
+		$db->beginTransaction();
+		
+		foreach ($queries as $query) {
+			if (preg_replace('/\s+/', '', $query) != '') {
+				$db->exec($query);
+			}
+		}
+
+		$db->commit();
 		
     }
     if($currentVersion < 4) {
@@ -146,11 +174,22 @@ if(isset($input->action) && $input->action == "requestUpgrade") {
 			  UNIQUE KEY namealgoindex (name, algorithm)
 			) Engine=InnoDB  DEFAULT CHARSET=latin1;
 			
+			ALTER TABLE user ADD UNIQUE KEY user_name_index (name);
+			
 			UPDATE options SET value=4 WHERE name='schema_version';
         ";
         $sql["pgsql"] = "UPDATE options SET value=4 WHERE name='schema_version';";
-		$stmt = $db->query($sql[$dbType]);
-		while ($stmt->nextRowset()) {;}
+		$queries = explode(";", $sql[$dbType]);
+		
+		$db->beginTransaction();
+		
+		foreach ($queries as $query) {
+			if (preg_replace('/\s+/', '', $query) != '') {
+				$db->exec($query);
+			}
+		}
+
+		$db->commit();
     }
     $retval['status'] = "success";
 }

--- a/api/users.php
+++ b/api/users.php
@@ -36,7 +36,7 @@ if(isset($input->action) && $input->action == "getUsers") {
 
     $sql = "
         SELECT id,name,type
-        FROM \"user\"
+        FROM users
         WHERE
             (name LIKE :name1 OR :name2) AND
             (type=:type1 OR :type2)
@@ -96,11 +96,11 @@ if(isset($input->action) && $input->action == "deleteUser") {
     
     $db->beginTransaction();
     
-    $stmt = $db->prepare("DELETE FROM permissions WHERE \"user\"=:userid");
+    $stmt = $db->prepare("DELETE FROM permissions WHERE userid=:userid");
 	$stmt->bindValue(':userid', $userId, PDO::PARAM_INT);
     $stmt->execute();
     
-    $stmt = $db->prepare("DELETE FROM \"user\" WHERE id=:id");
+    $stmt = $db->prepare("DELETE FROM users WHERE id=:id");
 	$stmt->bindValue(':id', $userId, PDO::PARAM_INT);
     $stmt->execute();
     

--- a/api/users.php
+++ b/api/users.php
@@ -36,7 +36,7 @@ if(isset($input->action) && $input->action == "getUsers") {
 
     $sql = "
         SELECT id,name,type
-        FROM user
+        FROM \"user\"
         WHERE
             (name LIKE :name1 OR :name2) AND
             (type=:type1 OR :type2)
@@ -96,11 +96,11 @@ if(isset($input->action) && $input->action == "deleteUser") {
     
     $db->beginTransaction();
     
-    $stmt = $db->prepare("DELETE FROM permissions WHERE user=:userid");
+    $stmt = $db->prepare("DELETE FROM permissions WHERE \"user\"=:userid");
 	$stmt->bindValue(':userid', $userId, PDO::PARAM_INT);
     $stmt->execute();
     
-    $stmt = $db->prepare("DELETE FROM user WHERE id=:id");
+    $stmt = $db->prepare("DELETE FROM \"user\" WHERE id=:id");
 	$stmt->bindValue(':id', $userId, PDO::PARAM_INT);
     $stmt->execute();
     

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -24,12 +24,6 @@ $config['db_password'] = "";
 $config['db_port'] = 3306;
 $config['db_name'] = "pdnsmanager";
 
-//HTTP API Settings
-$config['api_functionality'] = true;
-$config['api_host'] = "localhost"
-$config['api_port'] = 8080;
-$config['api_key'] = "";
-
 //Remote update
 $config['nonce_lifetime'] = 15;
 

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -24,6 +24,12 @@ $config['db_password'] = "";
 $config['db_port'] = 3306;
 $config['db_name'] = "pdnsmanager";
 
+//HTTP API Settings
+$config['api_functionality'] = true;
+$config['api_host'] = "localhost"
+$config['api_port'] = 8080;
+$config['api_key'] = "";
+
 //Remote update
 $config['nonce_lifetime'] = 15;
 

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -17,6 +17,7 @@
  */
 
 //Database settings
+$config['db_type'] = "mysql";
 $config['db_host'] = "localhost";
 $config['db_user'] = "root";
 $config['db_password'] = "";

--- a/domains.php
+++ b/domains.php
@@ -73,6 +73,8 @@ limitations under the License.
                                 <select class="form-control no-shadow" id="searchType">
                                     <option value="none">No filter...</option>
                                     <option value="MASTER">MASTER</option>
+									<option value="NATIVE">NATIVE</option>
+									<option value="SLAVE">SLAVE</option>
                                 </select>
                                 </div>
                             </form>
@@ -92,8 +94,9 @@ limitations under the License.
             <?php 
                 if($_SESSION['type'] == "admin") {
                     echo '<div class="row text-center">';
-                    echo '<a class="btn btn-success" href="add-domain.php#MASTER">Add MASTER</a>';
-                    echo '<a class="btn btn-primary margin-left-20" href="add-domain.php#NATIVE">Add NATIVE</a>';
+                    echo '<a class="btn btn-primary" href="add-domain.php#NATIVE">Add NATIVE</a>';
+                    echo '<a class="btn btn-success margin-left-20" href="add-domain.php#MASTER">Add MASTER</a>';
+                    echo '<a class="btn btn-success margin-left-20" href="add-domain.php#SLAVE">Add SLAVE</a>';
                     echo '</div>';
                 }
             ?>   

--- a/domains.php
+++ b/domains.php
@@ -96,7 +96,6 @@ limitations under the License.
                     echo '<div class="row text-center">';
                     echo '<a class="btn btn-primary" href="add-domain.php#NATIVE">Add NATIVE</a>';
                     echo '<a class="btn btn-success margin-left-20" href="add-domain.php#MASTER">Add MASTER</a>';
-                    echo '<a class="btn btn-success margin-left-20" href="add-domain.php#SLAVE">Add SLAVE</a>';
                     echo '</div>';
                 }
             ?>   

--- a/domains.php
+++ b/domains.php
@@ -74,7 +74,6 @@ limitations under the License.
                                     <option value="none">No filter...</option>
                                     <option value="MASTER">MASTER</option>
 									<option value="NATIVE">NATIVE</option>
-									<option value="SLAVE">SLAVE</option>
                                 </select>
                                 </div>
                             </form>

--- a/edit-master.php
+++ b/edit-master.php
@@ -70,7 +70,7 @@ limitations under the License.
                             </div>
                             <div class="form-group">
                                 <label for="soa-mail" class="control-label">Email</label>
-                                <input type="text" class="form-control" id="soa-mail" placeholder="Email" autocomplete="off" data-regex="^.+@[^.]+(\.[^.]+)*$" tabindex="2">
+                                <input type="email" class="form-control" id="soa-mail" placeholder="Email" autocomplete="off" tabindex="2">
                             </div>
                             <button disabled type="submit" class="btn btn-primary" tabindex="7">Save</button>
                         </div>

--- a/install.php
+++ b/install.php
@@ -64,7 +64,14 @@ limitations under the License.
                 <form>
                     <div class="container col-md-3">
                         <h3>Database</h3>
-                        
+                        <div class="form-group">
+                            <label for="dbType" class="control-label">Type</label>
+							<select class="form-control" name=dbType">
+								<option value="mysql" selected>MySQL</option>
+								<option value="pgsql">PgSQL</option>
+							</select>
+                            <input type="text" class="form-control" id="dbHost" placeholder="Host" autocomplete="off">
+                        </div>
                         <div class="form-group">
                             <label for="dbHost" class="control-label">Host</label>
                             <input type="text" class="form-control" id="dbHost" placeholder="Host" autocomplete="off">

--- a/install.php
+++ b/install.php
@@ -66,11 +66,10 @@ limitations under the License.
                         <h3>Database</h3>
                         <div class="form-group">
                             <label for="dbType" class="control-label">Type</label>
-							<select class="form-control" name=dbType">
+							<select class="form-control" id="dbType">
 								<option value="mysql" selected>MySQL</option>
 								<option value="pgsql">PgSQL</option>
 							</select>
-                            <input type="text" class="form-control" id="dbHost" placeholder="Host" autocomplete="off">
                         </div>
                         <div class="form-group">
                             <label for="dbHost" class="control-label">Host</label>

--- a/js/install.js
+++ b/js/install.js
@@ -51,7 +51,8 @@ function checkSettings() {
         database: $('#dbDatabase').val(),
         port: $('#dbPort').val(),
         userName: $('#adminName').val(),
-        userPassword: $('#adminPassword').val()
+        userPassword: $('#adminPassword').val(),
+        type:  $('#dbType').val()
     };
     
     $.post(

--- a/js/install.js
+++ b/js/install.js
@@ -52,7 +52,7 @@ function checkSettings() {
         port: $('#dbPort').val(),
         userName: $('#adminName').val(),
         userPassword: $('#adminPassword').val(),
-        type:  $('#dbType').val()
+        type: $('#dbType').val()
     };
     
     $.post(

--- a/lib/checkversion.php
+++ b/lib/checkversion.php
@@ -17,7 +17,7 @@
  */
 
 function getExpectedVersion() {
-    return 3;
+    return 4;
 }
 
 function checkVersion($db) {
@@ -29,19 +29,14 @@ function checkVersion($db) {
 }
 
 function getVersion($db) {
-    $stmt = $db->prepare("SHOW TABLES LIKE 'options'");
-    $stmt->execute();
-    $stmt->store_result();
-    if($stmt->num_rows() < 1) {
+	
+    try {
+		$stmt = $db->prepare("SELECT value FROM options WHERE name='schema_version' LIMIT 1");
+		$stmt->execute();
+		$version = $stmt->fetchColumn();
+    } catch (Exception $e) {
         return 0;
     }
-    $stmt->close();
-    
-    $stmt = $db->prepare("SELECT value FROM options WHERE name='schema_version'");
-    $stmt->execute();
-    $stmt->bind_result($version);
-    $stmt->fetch();
-    $stmt->close();
     
     return $version;    
 }

--- a/lib/checkversion.php
+++ b/lib/checkversion.php
@@ -30,13 +30,11 @@ function checkVersion($db) {
 
 function getVersion($db) {
 	
-    try {
-		$stmt = $db->prepare("SELECT value FROM options WHERE name='schema_version' LIMIT 1");
-		$stmt->execute();
-		$version = $stmt->fetchColumn();
-    } catch (Exception $e) {
-        return 0;
+	$stmt = $db->prepare("SELECT value FROM options WHERE name='schema_version' LIMIT 1");
+	$stmt->execute();
+	$version = $stmt->fetchColumn();
+    if (!$version) {
+		$version = 0;
     }
-    
     return $version;    
 }

--- a/lib/database.php
+++ b/lib/database.php
@@ -16,8 +16,9 @@
  * limitations under the License.
  */
 
-$db = new mysqli($config['db_host'], $config['db_user'], $config['db_password'], $config['db_name'], $config['db_port']);
-
-if ($db->connect_error) {
+try {
+	$db = new PDO("$config['db_type']:dbname=$config['db_name'];host=$config['db_host'];port=$config['db_port']", $config['db_user'], $config['db_password']);
+}
+catch (PDOException $e) {
     die("Connection to database failed");
 }

--- a/lib/database.php
+++ b/lib/database.php
@@ -17,7 +17,7 @@
  */
 
 try {
-	$db = new PDO("$config['db_type']:dbname=$config['db_name'];host=$config['db_host'];port=$config['db_port']", $config['db_user'], $config['db_password']);
+	$db = new PDO($config['db_type'].":dbname=".$config['db_name'].";host=".$config['db_host'].";port=".strval($config['db_port']), $config['db_user'], $config['db_password']);
 }
 catch (PDOException $e) {
     die("Connection to database failed");

--- a/lib/update-serial.php
+++ b/lib/update-serial.php
@@ -18,16 +18,13 @@
 
 function update_serial($db, $domainId) {
 
-    $db->autocommit(false);
-    $db->begin_transaction();
+    $db->beginTransaction();
     
-    $stmt = $db->prepare("SELECT content FROM records WHERE type='SOA' AND domain_id=?");
-    $stmt->bind_param("i", $domainId);
+    $stmt = $db->prepare("SELECT content FROM records WHERE type='SOA' AND domain_id=:domain_id LIMIT 1");
+    $stmt->bindValue(':domain_id', $domainId, PDO::PARAM_INT);
     $stmt->execute();
-    $stmt->bind_result($content);
-    $stmt->fetch();
-    $stmt->close();
-    
+    $content = $stmt->fetchColumn();
+	
     $content = explode(" ", $content);    
     
     $serial = $content[2];
@@ -50,8 +47,9 @@ function update_serial($db, $domainId) {
     
     $newsoa = implode(" ", $content);
     
-    $stmt = $db->prepare("UPDATE records SET content=? WHERE type='SOA' AND domain_id=?");
-    $stmt->bind_param("si", $newsoa, $domainId);
+    $stmt = $db->prepare("UPDATE records SET content=:content WHERE type='SOA' AND domain_id=:domain_id");
+	$stmt->bindValue(':content', $newsoa, PDO::PARAM_STR);
+    $stmt->bindValue(':domain_id', $domainId, PDO::PARAM_INT);
     $stmt->execute();
     
     $db->commit();


### PR DESCRIPTION
Summary of changes:
- user table renamed to users (postgres did not like this)
- user column in permissions renamed to userid
- users.name column now a unique key (duplicate users removed on upgrade)
- PDO now the SQL driver and postgres support added
- Powerdns 4 tables added
- SOA text input for email changed to email input and generic data validation removed
- added regex in the php interface to strip the soa email, soa name server, domain name and record name fields of whitespace and lower case of text (domain and record name columns forced to lower on upgrade)
- added trim to record content being inserted or updated
- changed some queries to be more universal (retrieving last id queries now use Max and queries where only one row is required use limit 1)
- if 0 domains are found page count is 1 so pagination disappears
- pagination now uses limit and offset instead of limit n,n
- added native to the domains filter drop down
- added database type option to install and configuration file

It should be pretty straight forward to add any other sql back ends now.