### PR TITLE
Change dbPort when dbType is changed during install.

### DIFF
--- a/js/install.js
+++ b/js/install.js
@@ -21,6 +21,14 @@ $(document).ready(function() {
         checkSettings();
     });
     
+    $('#dbType').change(function() {
+        if($(this).val() == 'mysql') {
+            $('#dbPort').val(3306);
+        } else if($(this).val() == 'pgsql') {
+            $('#dbPort').val(5432);
+        }
+    });
+    
     $('#adminPassword2').bind("change keyup paste", function() {
         if($('#adminPassword').val() == $('#adminPassword2').val()) {
             $(this).parent().removeClass("has-error");


### PR DESCRIPTION
If dbType is PgSQL, dbPort should be 5432 and not 3306 by default. 