### PR TITLE
Improve usability while adding records.

### DIFF
--- a/js/edit-master.js
+++ b/js/edit-master.js
@@ -339,10 +339,19 @@ function requestDomainName() {
             $('#domain-name').text(data.name);
             $('#add-domain-name').text("." + data.name);
             domainName = data.name;
+            setDefaultRecordType();
             $('#addButton').unbind().click(addRecord);
         },
         "json"
     );
+}
+function setDefaultRecordType() {
+    var reverseZone = false;
+    if(domainName.endsWith('.in-addr.arpa')) reverseZone = true;
+    if(domainName.endsWith('.ip6.arpa')) reverseZone = true;
+    if(reverseZone) {
+        $('#addType').val('PTR').change();
+    }
 }
 function enableFilter(enable) {
     if(enable) {

--- a/js/edit-master.js
+++ b/js/edit-master.js
@@ -304,11 +304,6 @@ function addRecord() {
             $('#table-records>tbody>tr').last().find('span.glyphicon-trash').click(trashClicked);
             $('#table-records>tbody>tr').last().find('span.glyphicon-share').click(remoteClicked);
             requestSerial();
-            $('#addName').val("");
-            $('#addType').val("A").change();
-            $('#addContent').val("");
-            $('#addPrio').val("");
-            $('#addTtl').val("");
         },
         "json"
     );


### PR DESCRIPTION
Two changes to improve the usability while adding records.

- First keep the input data after a new record was submitted. This is useful if one wants two add several similar records at once. E.g. if one introduces IPv6 one maybe has to add 50 ore more records to the database. All of them will type AAAA and have the same prefix in the data. So one is faster by modifying the previous record than by starting with an empty line again. Other examples for similar records are round robin records and multiple MX or NS records.

- Second set the record type to PTR if a reverse zone (in-addr.arpa or ip6.arpa) is detected because almost all records in a reverse zone are PTR records.