### PR TITLE
Add basic LDAP support

### DIFF
--- a/README.LDAP.md
+++ b/README.LDAP.md
@@ -1,0 +1,25 @@
+# LDAP integration
+
+Basic LDAP authentication support can be enabled in the configuration file.
+LDAP users can login with their credentials and manage PowerDNS zones.
+It is possible to restrict the access to users with certain LDAP attributes.
+
+## Configuration Example
+
+In order to enable LDAP support put the following lines into your config-user.php file and adjust the parameters for your setup.
+
+    $config['auth_type'] = 'ldap';
+    $config['ldap_uri'] = 'ldap://ldap.example.com/';
+    $config['ldap_bind_dn'] = 'uid=admin,ou=users,dc=example,dc=com';
+    $config['ldap_bind_pw'] = 'password';
+    $config['ldap_base_dn'] = 'dc=example,dc=com';
+    $config['ldap_search'] = '(&(uid=%user%)(memberof=cn=dns,ou=groups,dc=example,dc=com))';
+
+Adjust the ldap_search parameter to control which users are allowed to login and to manage PowerDNS zones.
+
+## Known limitations
+
+ * LDAP has to be enabled and configured manually in the configuration file.
+ * Either database or LDAP can be used for authentication. Internal authentication will be disabled if LDAP is enabled.
+ * LDAP users have either full rights for all zones or are not allowed to login. Use the ldap_search parameter to adjust which users can login.
+

--- a/add-domain.php
+++ b/add-domain.php
@@ -35,8 +35,8 @@ limitations under the License.
                 </div>
                 <ul class="nav navbar-nav">
                     <li><a href="domains.php">Domains</a></li>
-                    <?php if($_SESSION['type'] == "admin") echo '<li><a href="users.php">Users</a></li>'; ?>
-                    <li><a href="password.php">Password</a></li>
+                    <?php if($_SESSION['type'] == "admin" and $_SESSION['id'] > 0) echo '<li><a href="users.php">Users</a></li>'; ?>
+                    <?php if($_SESSION['id'] > 0) echo '<li><a href="password.php">Password</a></li>'; ?>
                     <li><a href="logout.php">Logout</a></li>
                 </ul>
             </div>

--- a/api/edit-user.php
+++ b/api/edit-user.php
@@ -26,6 +26,10 @@ if(!isset($_SESSION['type']) || $_SESSION['type'] != "admin") {
     echo "Permission denied!";
     exit();
 }
+if(!isset($_SESSION['id']) || $_SESSION['id'] == 0) {
+    echo "Permission denied!";
+    exit();
+}
 if(isset($input->action) && $input->action == "addUser") {
     $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
     $db->beginTransaction();

--- a/api/index.php
+++ b/api/index.php
@@ -40,7 +40,10 @@ if ($config['auth_type'] == 'db') {
 	}
 } elseif ($config['auth_type'] == 'ldap') {
 	$ldap = @ldap_connect($config['ldap_uri']);
-	@ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
+	@ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, $config['ldap_version']);
+	if ($config['ldap_starttls']) {
+		@ldap_start_tls($ldap);
+	}
 	@ldap_bind($ldap, $config['ldap_bind_dn'], $config['ldap_bind_pw']);
 	$filter = str_replace('%user%', @ldap_escape($input->user, null, LDAP_ESCAPE_FILTER), $config['ldap_search']);
 	$result = @ldap_search($ldap, $config['ldap_base_dn'], $filter, array('dn'));

--- a/api/index.php
+++ b/api/index.php
@@ -42,7 +42,7 @@ if ($config['auth_type'] == 'db') {
 	$ldap = @ldap_connect($config['ldap_uri']);
 	@ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
 	@ldap_bind($ldap, $config['ldap_bind_dn'], $config['ldap_bind_pw']);
-	$filter = str_replace('%user%', $input->user, $config['ldap_search']);
+	$filter = str_replace('%user%', @ldap_escape($input->user, null, LDAP_ESCAPE_FILTER), $config['ldap_search']);
 	$result = @ldap_search($ldap, $config['ldap_base_dn'], $filter, array('dn'));
 	$dn = @ldap_get_dn($ldap, ldap_first_entry($ldap, $result));
 	if (@ldap_bind($ldap, $dn, $input->password)) {

--- a/api/index.php
+++ b/api/index.php
@@ -17,24 +17,48 @@
 require_once '../config/config-default.php';
 require_once '../lib/database.php';
 $input = json_decode(file_get_contents('php://input'));
-$stmt = $db->prepare("SELECT id,password,type FROM users WHERE name=:name LIMIT 1");
-$stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
-$stmt->execute();
-$stmt->bindColumn('id', $id);
-$stmt->bindColumn('password', $password);
-$stmt->bindColumn('type', $type);
-$stmt->fetch(PDO::FETCH_BOUND);
-if (password_verify($input->password, $password)) {
-    $retval['status'] = "success";
-    session_start();
-    $_SESSION['id'] = $id;
-    $_SESSION['type'] = $type;
-    $randomSecret = base64_encode(openssl_random_pseudo_bytes(32));
-    $_SESSION['secret'] = $randomSecret;
-    setcookie("authSecret", $randomSecret, 0, "/", "", false, true);
-    $csrfToken = base64_encode(openssl_random_pseudo_bytes(32));
-    $_SESSION['csrfToken'] = $csrfToken;
+if ($config['auth_type'] == 'db') {
+	$stmt = $db->prepare('SELECT id,password,type FROM users WHERE name=:name LIMIT 1');
+	$stmt->bindValue(':name', $input->user, PDO::PARAM_STR);
+	$stmt->execute();
+	$stmt->bindColumn('id', $id);
+	$stmt->bindColumn('password', $password);
+	$stmt->bindColumn('type', $type);
+	$stmt->fetch(PDO::FETCH_BOUND);
+	if (password_verify($input->password, $password)) {
+		$retval['status'] = 'success';
+		session_start();
+		$_SESSION['id'] = $id;
+		$_SESSION['type'] = $type;
+		$randomSecret = base64_encode(openssl_random_pseudo_bytes(32));
+		$_SESSION['secret'] = $randomSecret;
+		setcookie('authSecret', $randomSecret, 0, '/', '', false, true);
+		$csrfToken = base64_encode(openssl_random_pseudo_bytes(32));
+		$_SESSION['csrfToken'] = $csrfToken;
+	} else {
+		$retval['status'] = 'fail';
+	}
+} elseif ($config['auth_type'] == 'ldap') {
+	$ldap = @ldap_connect($config['ldap_uri']);
+	@ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
+	@ldap_bind($ldap, $config['ldap_bind_dn'], $config['ldap_bind_pw']);
+	$filter = str_replace('%user%', $input->user, $config['ldap_search']);
+	$result = @ldap_search($ldap, $config['ldap_base_dn'], $filter, array('dn'));
+	$dn = @ldap_get_dn($ldap, ldap_first_entry($ldap, $result));
+	if (@ldap_bind($ldap, $dn, $input->password)) {
+		$retval['status'] = 'success';
+		session_start();
+		$_SESSION['id'] = 0;
+		$_SESSION['type'] = 'admin';
+		$randomSecret = base64_encode(openssl_random_pseudo_bytes(32));
+		$_SESSION['secret'] = $randomSecret;
+		setcookie('authSecret', $randomSecret, 0, '/', '', false, true);
+		$csrfToken = base64_encode(openssl_random_pseudo_bytes(32));
+		$_SESSION['csrfToken'] = $csrfToken;
+	} else {
+		$retval['status'] = 'fail';
+	}
 } else {
-    $retval['status'] = "fail";
+	$retval['status'] = 'fail';
 }
 echo json_encode($retval);

--- a/api/password.php
+++ b/api/password.php
@@ -22,6 +22,10 @@ if(!isset($input->csrfToken) || $input->csrfToken !== $_SESSION['csrfToken']) {
     echo "Permission denied!";
     exit();
 }
+if(!isset($_SESSION['id']) || $_SESSION['id'] == 0) {
+    echo "Permission denied!";
+    exit();
+}
 if(isset($input->action) && $input->action == "changePassword") {
     $passwordHash = password_hash($input->password, PASSWORD_DEFAULT);
     $stmt = $db->prepare("UPDATE users SET password=:password WHERE id=:id");

--- a/api/users.php
+++ b/api/users.php
@@ -26,6 +26,10 @@ if(!isset($_SESSION['type']) || $_SESSION['type'] != "admin") {
     echo "Permission denied!";
     exit();
 }
+if(!isset($_SESSION['id']) || $_SESSION['id'] == 0) {
+    echo "Permission denied!";
+    exit();
+}
 if(isset($input->action) && $input->action == "getUsers") {
     $sql = "
         SELECT id,name,type

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -28,6 +28,8 @@ $config['auth_type'] = 'db';
 
 // LDAP settings
 $config['ldap_uri'] = 'ldapi:///';
+$config['ldap_version'] = 3;
+$config['ldap_starttls'] = false;
 $config['ldap_bind_dn'] = '';
 $config['ldap_bind_pw'] = '';
 $config['ldap_base_dn'] = '';

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -23,6 +23,9 @@ $config['db_password'] = "";
 $config['db_port'] = 3306;
 $config['db_name'] = "pdnsmanager";
 
+// Authentication source
+$config['auth_type'] = 'db';
+
 //Remote update
 $config['nonce_lifetime'] = 15;
 

--- a/config/config-default.php
+++ b/config/config-default.php
@@ -26,6 +26,13 @@ $config['db_name'] = "pdnsmanager";
 // Authentication source
 $config['auth_type'] = 'db';
 
+// LDAP settings
+$config['ldap_uri'] = 'ldapi:///';
+$config['ldap_bind_dn'] = '';
+$config['ldap_bind_pw'] = '';
+$config['ldap_base_dn'] = '';
+$config['ldap_search'] = 'uid=%user%';
+
 //Remote update
 $config['nonce_lifetime'] = 15;
 

--- a/domains.php
+++ b/domains.php
@@ -38,8 +38,8 @@ limitations under the License.
                 </div>
                 <ul class="nav navbar-nav">
                     <li class="active"><a href="domains.php">Domains</a></li>
-                    <?php if($_SESSION['type'] == "admin") echo '<li><a href="users.php">Users</a></li>'; ?>
-                    <li><a href="password.php">Password</a></li>
+                    <?php if($_SESSION['type'] == "admin" and $_SESSION['id'] > 0) echo '<li><a href="users.php">Users</a></li>'; ?>
+                    <?php if($_SESSION['id'] > 0) echo '<li><a href="password.php">Password</a></li>'; ?>
                     <li><a href="logout.php">Logout</a></li>
                 </ul>
             </div>

--- a/edit-master.php
+++ b/edit-master.php
@@ -38,8 +38,8 @@ limitations under the License.
                 </div>
                 <ul class="nav navbar-nav">
                     <li><a href="domains.php">Domains</a></li>
-                    <?php if($_SESSION['type'] == "admin") echo '<li><a href="users.php">Users</a></li>'; ?>
-                    <li><a href="password.php">Password</a></li>
+                    <?php if($_SESSION['type'] == "admin" and $_SESSION['id'] > 0) echo '<li><a href="users.php">Users</a></li>'; ?>
+                    <?php if($_SESSION['id'] > 0) echo '<li><a href="password.php">Password</a></li>'; ?>
                     <li><a href="logout.php">Logout</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
This patch adds basic LDAP support to pdnsmanager. It can be enabled in the configuration file. LDAP users can login with their credentials and manage PowerDNS zones. It is possible to restrict the access to users with certain LDAP attributes.

Known limitations:
 * LDAP has to be enabled and configured manually in the configuration file.
 * Either database or LDAP can be used for authentication. Internal authentication will be disabled if LDAP is enabled.
 * LDAP users have either full rights for all zones or are not allowed to login. The ldap_search parameter can be used to adjust which users can login.