### PR TITLE
Native user backend fix

### DIFF
--- a/backend/src/config/ConfigDefault.php
+++ b/backend/src/config/ConfigDefault.php
@@ -38,7 +38,7 @@ $defaultConfig = [
         ]
     ],
     'proxys' => [],
-    'dbVersion' => 5
+    'dbVersion' => 6
 ];
 
 if (file_exists('../config/ConfigOverride.php')) {

--- a/backend/src/sql/Update6.sql
+++ b/backend/src/sql/Update6.sql
@@ -1,0 +1,3 @@
+UPDATE users SET backend='native' WHERE backend='';
+
+UPDATE options SET value=6 WHERE name='schema_version';


### PR DESCRIPTION
This patch is fixing issue #79 - User could not login after the upgrade. The fix assumes that all old users were local only thus it sets all users with empty (unset) backend to native backend.